### PR TITLE
docs: Update config setting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ module.exports = {
     {
       resolve: "gatsby-source-tribe-events",
       options: {
-        // baseURL should include the protocol (https or http)
-        baseURL: "https://mysite.tld",
+        // baseUrl should include the protocol (https or http)
+        baseUrl: "https://mysite.tld",
 
         // maxEvents is optional, default: 10, max: 50
         maxEvents: 10


### PR DESCRIPTION
Setting the option as `baseURL` didn't work for me - setting it to `baseUrl` did, however.